### PR TITLE
[BE] 기사 관련 API 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
+	id 'org.springframework.boot' version '3.2.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/backend/src/main/java/com/newslearning/domain/article/Article.java
+++ b/backend/src/main/java/com/newslearning/domain/article/Article.java
@@ -1,0 +1,92 @@
+package com.newslearning.domain.article;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "articles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Article {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 300)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "short_summary", length = 300)
+    private String shortSummary;
+
+    @Column(name = "middle_summary", length = 300)
+    private String middleSummary;
+
+    @Column(name = "image_url", length = 300)
+    private String imageUrl;
+
+    @Column(length = 100, nullable = false)
+    private String reporter;
+
+    @Column(name = "source_url", length = 500, nullable = false)
+    private String sourceUrl;
+
+    @Column(name = "media_name", length = 100, nullable = false)
+    private String mediaName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    public enum Category {
+        POLITICS("정치"),
+        ECONOMY("경제"),
+        SOCIETY("사회"),
+        CULTURE("연예"),
+        WORLD("국제"),
+        SPORTS("스포츠"),
+        ETC("전체"); 
+
+        private final String korean;
+
+        Category(String korean) {
+            this.korean = korean;
+        }
+
+        public String getKorean() {
+            return korean;
+        }
+
+        public static Category fromKorean(String korean) {
+            return Arrays.stream(Category.values())
+                .filter(c -> c.korean.equals(korean))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("알 수 없는 카테고리: " + korean));
+        }
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
@@ -6,11 +6,13 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.newslearning.domain.article.dto.ArticleScrollResponseDto;
+import com.newslearning.domain.article.dto.ArticleDetailResponseDTO;
+import com.newslearning.domain.article.dto.ArticleScrollResponseDTO;
 import com.newslearning.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,12 +29,19 @@ public class ArticleController {
 
     @Operation(summary = "기사 목록 조회", description = "카테고리, 검색어, 커서를 기반으로 기사 목록을 무한스크롤 방식으로 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<ArticleScrollResponseDto>> getArticles(
+    public ResponseEntity<ApiResponse<ArticleScrollResponseDTO>> getArticles(
         @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime cursorPublishedAt,
         @RequestParam(defaultValue = "10") int size,
         @RequestParam(required = false) String category, 
         @RequestParam(required = false) String keyword) {
-        ArticleScrollResponseDto response = articleService.getArticles(keyword, category, cursorPublishedAt, size);
+        ArticleScrollResponseDTO response = articleService.getArticles(keyword, category, cursorPublishedAt, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "단일 기사 조회", description = "기사 ID를 기반으로 기사의 상세 정보를 조회합니다.(한자어 포함, 퀴즈 제외)")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ArticleDetailResponseDTO>> getArticleById(@PathVariable Long id) {
+        ArticleDetailResponseDTO response = articleService.getArticleDetail(id);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
@@ -1,0 +1,35 @@
+package com.newslearning.domain.article;
+
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newslearning.domain.article.dto.ArticleScrollResponseDto;
+import com.newslearning.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/articles")
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    @Operation(summary = "기사 목록 조회", description = "publishedAt 기준 내림차순 커서 기반 무한스크롤용 기사 목록을 반환합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<ArticleScrollResponseDto>> getArticles(
+        @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime cursorPublishedAt,
+        @RequestParam(defaultValue = "10") int size) {
+        ArticleScrollResponseDto response = articleService.getArticles(cursorPublishedAt, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}
+

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
@@ -14,8 +14,10 @@ import com.newslearning.domain.article.dto.ArticleScrollResponseDto;
 import com.newslearning.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Article", description = "뉴스 기사 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/articles")
@@ -23,12 +25,13 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
-    @Operation(summary = "기사 목록 조회", description = "publishedAt 기준 내림차순 커서 기반 무한스크롤용 기사 목록을 반환합니다.")
+    @Operation(summary = "기사 목록 조회", description = "카테고리 및 커서를 기반으로 기사 목록을 무한스크롤 방식으로 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<ArticleScrollResponseDto>> getArticles(
         @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime cursorPublishedAt,
-        @RequestParam(defaultValue = "10") int size) {
-        ArticleScrollResponseDto response = articleService.getArticles(cursorPublishedAt, size);
+        @RequestParam(defaultValue = "10") int size,
+        @RequestParam(required = false) String category) {
+        ArticleScrollResponseDto response = articleService.getArticles(category, cursorPublishedAt, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
@@ -7,16 +7,20 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.newslearning.domain.article.dto.ArticleDetailResponseDTO;
+import com.newslearning.domain.article.dto.ArticleRequestDTO;
 import com.newslearning.domain.article.dto.ArticleScrollResponseDTO;
 import com.newslearning.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Article", description = "뉴스 기사 API")
@@ -43,6 +47,14 @@ public class ArticleController {
     public ResponseEntity<ApiResponse<ArticleDetailResponseDTO>> getArticleById(@PathVariable Long id) {
         ArticleDetailResponseDTO response = articleService.getArticleDetail(id);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "기사 + 한자 + 퀴즈 일괄 등록", description = "기사, 한자, 퀴즈 정보를 포함한 DTO를 기반으로 일괄 등록합니다. ")
+    @PostMapping("/add")
+    public ResponseEntity<ApiResponse<Void>> addArticle(
+            @Valid @RequestBody ArticleRequestDTO request) {
+        articleService.addArticle(request);
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }
 

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleController.java
@@ -25,13 +25,14 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
-    @Operation(summary = "기사 목록 조회", description = "카테고리 및 커서를 기반으로 기사 목록을 무한스크롤 방식으로 조회합니다.")
+    @Operation(summary = "기사 목록 조회", description = "카테고리, 검색어, 커서를 기반으로 기사 목록을 무한스크롤 방식으로 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<ArticleScrollResponseDto>> getArticles(
         @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime cursorPublishedAt,
         @RequestParam(defaultValue = "10") int size,
-        @RequestParam(required = false) String category) {
-        ArticleScrollResponseDto response = articleService.getArticles(category, cursorPublishedAt, size);
+        @RequestParam(required = false) String category, 
+        @RequestParam(required = false) String keyword) {
+        ArticleScrollResponseDto response = articleService.getArticles(keyword, category, cursorPublishedAt, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
@@ -1,0 +1,15 @@
+package com.newslearning.domain.article;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    // 커서 없이 첫 페이지를 조회할 때 사용
+    Slice<Article> findAllByOrderByPublishedAtDesc(Pageable pageable);
+
+    // 커서가 있는 경우 해당 시각 이전 기사부터 조회
+    Slice<Article> findByPublishedAtLessThanOrderByPublishedAtDesc(LocalDateTime publishedAt, Pageable pageable);
+}

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.newslearning.domain.article.entity.Article;
+
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     // 커서 없이 첫 페이지를 조회할 때 사용
     Slice<Article> findAllByOrderByPublishedAtDesc(Pageable pageable);

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
@@ -18,4 +18,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     // 특정 카테고리에서 커서를 기준으로 이전 기사들을 조회.
     Slice<Article> findByCategoryAndPublishedAtLessThanOrderByPublishedAtDesc(Article.Category category, LocalDateTime publishedAt, Pageable pageable);
+
+    // 검색어로 기사 제목을 포함하는 기사들을 커서 없이 처음부터 조회.
+    Slice<Article> findByTitleContainingIgnoreCaseOrderByPublishedAtDesc(String keyword, Pageable pageable);
+
+    // 검색어로 기사 제목을 포함하고, 커서를 기준으로 이전 기사들을 조회.
+    Slice<Article> findByTitleContainingIgnoreCaseAndPublishedAtLessThanOrderByPublishedAtDesc(String keyword, LocalDateTime publishedAt, Pageable pageable);
+
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleRepository.java
@@ -12,4 +12,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     // 커서가 있는 경우 해당 시각 이전 기사부터 조회
     Slice<Article> findByPublishedAtLessThanOrderByPublishedAtDesc(LocalDateTime publishedAt, Pageable pageable);
+
+    // 특정 카테고리 내 기사들을 커서 없이 처음부터 조회할 때 사용.
+    Slice<Article> findByCategoryOrderByPublishedAtDesc(Article.Category category, Pageable pageable);
+
+    // 특정 카테고리에서 커서를 기준으로 이전 기사들을 조회.
+    Slice<Article> findByCategoryAndPublishedAtLessThanOrderByPublishedAtDesc(Article.Category category, LocalDateTime publishedAt, Pageable pageable);
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
@@ -9,8 +9,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.newslearning.domain.article.dto.ArticleResponseDto;
-import com.newslearning.domain.article.dto.ArticleScrollResponseDto;
+import com.newslearning.domain.article.dto.ArticleDetailResponseDTO;
+import com.newslearning.domain.article.dto.ArticleResponseDTO;
+import com.newslearning.domain.article.dto.ArticleScrollResponseDTO;
+import com.newslearning.domain.article.entity.Article;
+import com.newslearning.domain.hanja.HanjaService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,10 +22,11 @@ import lombok.RequiredArgsConstructor;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final HanjaService hanjaService;
     
     // 커서 기반 무한 스크롤을 위한 기사 목록 조회
     @Transactional(readOnly = true)
-    public ArticleScrollResponseDto getArticles(String keyword, String category, LocalDateTime cursorPublishedAt, int size) {
+    public ArticleScrollResponseDTO getArticles(String keyword, String category, LocalDateTime cursorPublishedAt, int size) {
         Pageable pageable = PageRequest.of(0, size);
 
         Slice<Article> slice;
@@ -48,8 +52,8 @@ public class ArticleService {
 
         }
         
-        List<ArticleResponseDto> dtoList = slice.getContent().stream()
-            .map(ArticleResponseDto::from)
+        List<ArticleResponseDTO> dtoList = slice.getContent().stream()
+            .map(ArticleResponseDTO::from)
             .toList();
 
         // 다음 페이지 요청 시 기준이 되는 커서 값
@@ -57,6 +61,17 @@ public class ArticleService {
             ? dtoList.get(dtoList.size() - 1).publishedAt()
             : null;
 
-        return new ArticleScrollResponseDto(dtoList, slice.hasNext(), nextCursorPublishedAt);
+        return new ArticleScrollResponseDTO(dtoList, slice.hasNext(), nextCursorPublishedAt);
+    }
+
+    // 특정 기사 상세 조회
+    @Transactional(readOnly = true)
+    public ArticleDetailResponseDTO getArticleDetail(Long articleId) {
+        Article article = articleRepository.findById(articleId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 기사가 존재하지 않습니다. id=" + articleId));
+
+        // 버전별 한자어만 묶어서 응답 (퀴즈는 제외)
+        var hanjaByVersion = hanjaService.findGroupedByVersion(articleId);
+        return ArticleDetailResponseDTO.of(article, hanjaByVersion);
     }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.newslearning.domain.article.dto.ArticleResponseDto;
 import com.newslearning.domain.article.dto.ArticleScrollResponseDto;
@@ -20,19 +21,27 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     
     // 커서 기반 무한 스크롤을 위한 기사 목록 조회
-    public ArticleScrollResponseDto getArticles(String category, LocalDateTime cursorPublishedAt, int size) {
+    @Transactional(readOnly = true)
+    public ArticleScrollResponseDto getArticles(String keyword, String category, LocalDateTime cursorPublishedAt, int size) {
         Pageable pageable = PageRequest.of(0, size);
 
         Slice<Article> slice;
 
+        // 검색어 있는 경우
+        if (keyword != null && !keyword.isBlank()) {
+            slice = (cursorPublishedAt == null)
+                ? articleRepository.findByTitleContainingIgnoreCaseOrderByPublishedAtDesc(keyword, pageable)
+                : articleRepository.findByTitleContainingIgnoreCaseAndPublishedAtLessThanOrderByPublishedAtDesc(keyword, cursorPublishedAt, pageable);
+
         // 카테고리 조건이 있는 경우
-        if (category != null) {
+        } else if (category != null) {
             Article.Category cat = Article.Category.valueOf(category.toUpperCase());
             slice = (cursorPublishedAt == null)
                 ? articleRepository.findByCategoryOrderByPublishedAtDesc(cat, pageable)
                 : articleRepository.findByCategoryAndPublishedAtLessThanOrderByPublishedAtDesc(cat, cursorPublishedAt, pageable);
+
+        // 기본 전체 조회
         } else {
-            // 전체 카테고리 대상 조회
             slice = (cursorPublishedAt == null)
                 ? articleRepository.findAllByOrderByPublishedAtDesc(pageable)
                 : articleRepository.findByPublishedAtLessThanOrderByPublishedAtDesc(cursorPublishedAt, pageable);

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
@@ -1,0 +1,42 @@
+package com.newslearning.domain.article;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import com.newslearning.domain.article.dto.ArticleResponseDto;
+import com.newslearning.domain.article.dto.ArticleScrollResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    
+    // 커서 기반 무한 스크롤을 위한 기사 목록 조회
+    public ArticleScrollResponseDto getArticles(LocalDateTime cursorPublishedAt, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        // 커서가 null이면 최신 기사부터 조회, 있으면 해당 시각 이전 기사부터 조회
+        Slice<Article> slice = (cursorPublishedAt == null)
+            ? articleRepository.findAllByOrderByPublishedAtDesc(pageable)
+            : articleRepository.findByPublishedAtLessThanOrderByPublishedAtDesc(cursorPublishedAt, pageable);
+
+        List<ArticleResponseDto> dtoList = slice.getContent().stream()
+            .map(ArticleResponseDto::from)
+            .toList();
+
+        // 다음 페이지 요청 시 기준이 되는 커서 값
+        LocalDateTime nextCursorPublishedAt = slice.hasNext()
+            ? dtoList.get(dtoList.size() - 1).publishedAt()
+            : null;
+
+        return new ArticleScrollResponseDto(dtoList, slice.hasNext(), nextCursorPublishedAt);
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
@@ -10,11 +10,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.newslearning.domain.article.dto.ArticleDetailResponseDTO;
+import com.newslearning.domain.article.dto.ArticleRequestDTO;
 import com.newslearning.domain.article.dto.ArticleResponseDTO;
 import com.newslearning.domain.article.dto.ArticleScrollResponseDTO;
 import com.newslearning.domain.article.entity.Article;
+import com.newslearning.domain.hanja.Hanja;
+import com.newslearning.domain.hanja.HanjaRepository;
 import com.newslearning.domain.hanja.HanjaService;
+import com.newslearning.domain.quiz.Quiz;
+import com.newslearning.domain.quiz.QuizRepository;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,6 +30,16 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
     private final HanjaService hanjaService;
+    private final HanjaRepository hanjaRepository;
+    private final QuizRepository quizRepository;
+
+    @Getter
+    @AllArgsConstructor
+    public static class IngestResult {
+        private Long articleId;
+        private int hanjaInserted;
+        private int quizInserted;
+    }
     
     // 커서 기반 무한 스크롤을 위한 기사 목록 조회
     @Transactional(readOnly = true)
@@ -73,5 +90,69 @@ public class ArticleService {
         // 버전별 한자어만 묶어서 응답 (퀴즈는 제외)
         var hanjaByVersion = hanjaService.findGroupedByVersion(articleId);
         return ArticleDetailResponseDTO.of(article, hanjaByVersion);
+    }
+
+    /**
+     * 파이썬 → 스프링 한 번의 요청으로
+     * 기사 + 한자 + 퀴즈를 INSERT 합니다. (UPSERT X)
+     * 유니크 제약 위반 시 DataIntegrityViolationException 발생 가능.
+     */
+    @Transactional
+    public IngestResult addArticle(ArticleRequestDTO req) {
+        // 0) 타임스탬프 기본값
+        LocalDateTime createdTs = LocalDateTime.now();
+
+        // 1) Article 저장 (단순 insert)
+        Article article = Article.builder()
+            .title(req.getTitle())
+            .content(req.getContent())
+            .shortSummary(req.getShortSummary())
+            .middleSummary(req.getMiddleSummary())
+            .imageUrl(req.getImageUrl())
+            .reporter(req.getReporter())
+            .sourceUrl(req.getSourceUrl())
+            .mediaName(req.getMediaName())
+            .category(req.getCategory())
+            .publishedAt(req.getPublishedAt())
+            .createdAt(LocalDateTime.now())
+            .build();
+        article = articleRepository.save(article);
+
+        // 2) Hanja 저장 + 3) Quiz 저장 (단순 insert)
+        int hanjaCnt = 0;
+        int quizCnt  = 0;
+
+        if (req.getHanjas() != null) {
+            for (var hb : req.getHanjas()) {
+                Hanja hanja = Hanja.builder()
+                    .article(article)
+                    .version(hb.getVersion())
+                    .word(hb.getWord())
+                    .definition(hb.getDefinition())
+                    .createdAt(createdTs)
+                    .build();
+                hanja = hanjaRepository.save(hanja);
+                hanjaCnt++;
+
+                if (hb.getQuizzes() != null) {
+                    for (var qb : hb.getQuizzes()) {
+                        Quiz quiz = Quiz.builder()
+                            .article(article)
+                            .hanja(hanja)
+                            .question(qb.getQuestion())
+                            .answer1(qb.getAnswer1())
+                            .answer2(qb.getAnswer2())
+                            .answer3(qb.getAnswer3())
+                            .correct(qb.getCorrect())
+                            .createdAt(createdTs)
+                            .build();
+                        quizRepository.save(quiz);
+                        quizCnt++;
+                    }
+                }
+            }
+        }
+
+        return new IngestResult(article.getId(), hanjaCnt, quizCnt);
     }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
@@ -20,14 +20,25 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     
     // 커서 기반 무한 스크롤을 위한 기사 목록 조회
-    public ArticleScrollResponseDto getArticles(LocalDateTime cursorPublishedAt, int size) {
+    public ArticleScrollResponseDto getArticles(String category, LocalDateTime cursorPublishedAt, int size) {
         Pageable pageable = PageRequest.of(0, size);
 
-        // 커서가 null이면 최신 기사부터 조회, 있으면 해당 시각 이전 기사부터 조회
-        Slice<Article> slice = (cursorPublishedAt == null)
-            ? articleRepository.findAllByOrderByPublishedAtDesc(pageable)
-            : articleRepository.findByPublishedAtLessThanOrderByPublishedAtDesc(cursorPublishedAt, pageable);
+        Slice<Article> slice;
 
+        // 카테고리 조건이 있는 경우
+        if (category != null) {
+            Article.Category cat = Article.Category.valueOf(category.toUpperCase());
+            slice = (cursorPublishedAt == null)
+                ? articleRepository.findByCategoryOrderByPublishedAtDesc(cat, pageable)
+                : articleRepository.findByCategoryAndPublishedAtLessThanOrderByPublishedAtDesc(cat, cursorPublishedAt, pageable);
+        } else {
+            // 전체 카테고리 대상 조회
+            slice = (cursorPublishedAt == null)
+                ? articleRepository.findAllByOrderByPublishedAtDesc(pageable)
+                : articleRepository.findByPublishedAtLessThanOrderByPublishedAtDesc(cursorPublishedAt, pageable);
+
+        }
+        
         List<ArticleResponseDto> dtoList = slice.getContent().stream()
             .map(ArticleResponseDto::from)
             .toList();

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleDetailResponseDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleDetailResponseDTO.java
@@ -1,0 +1,59 @@
+package com.newslearning.domain.article.dto;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import com.newslearning.domain.article.entity.Article;
+import com.newslearning.domain.article.entity.SummaryVersion;
+import com.newslearning.domain.hanja.Hanja;
+import com.newslearning.domain.hanja.dto.HanjaDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @AllArgsConstructor @NoArgsConstructor
+public class ArticleDetailResponseDTO {
+    private Long articleId;
+    private String title;
+    private String reporter;
+    private String mediaName;
+    private String imageUrl;
+    private Map<SummaryVersion, SummaryBlock> summaries;
+
+    @Getter @AllArgsConstructor @NoArgsConstructor
+    public static class SummaryBlock {
+        private String content;
+        private List<HanjaDTO> hanjaWords; 
+    }
+
+    public static ArticleDetailResponseDTO of(
+        Article article,
+        Map<SummaryVersion, List<Hanja>> hanjaByVersion
+    ) {
+        Map<SummaryVersion, SummaryBlock> map = new EnumMap<>(SummaryVersion.class);
+
+        map.put(SummaryVersion.ORIGINAL, new SummaryBlock(
+            article.getContent(),
+            hanjaByVersion.getOrDefault(SummaryVersion.ORIGINAL, List.of()).stream().map(HanjaDTO::from).toList()
+        ));
+        map.put(SummaryVersion.SHORT, new SummaryBlock(
+            article.getShortSummary(),
+            hanjaByVersion.getOrDefault(SummaryVersion.SHORT, List.of()).stream().map(HanjaDTO::from).toList()
+        ));
+        map.put(SummaryVersion.MIDDLE, new SummaryBlock(
+            article.getMiddleSummary(),
+            hanjaByVersion.getOrDefault(SummaryVersion.MIDDLE, List.of()).stream().map(HanjaDTO::from).toList()
+        ));
+
+        return new ArticleDetailResponseDTO(
+            article.getId(),
+            article.getTitle(),
+            article.getReporter(),
+            article.getMediaName(),
+            article.getImageUrl(),
+            map
+        );
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleRequestDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleRequestDTO.java
@@ -1,0 +1,5 @@
+package com.newslearning.domain.article.dto;
+
+public class ArticleRequestDTO {
+    
+}

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleRequestDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleRequestDTO.java
@@ -1,5 +1,55 @@
+// package: com.newslearning.domain.article.dto
 package com.newslearning.domain.article.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.newslearning.domain.article.entity.Article.Category;
+import com.newslearning.domain.article.entity.SummaryVersion;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
 public class ArticleRequestDTO {
-    
+
+    // ===== Article =====
+    @NotBlank private String title;
+    @NotBlank private String content;
+    private String shortSummary;
+    private String middleSummary;
+
+    private String imageUrl;
+    @NotBlank private String reporter;
+    @NotBlank private String sourceUrl;   // 중복 방지 키로 사용 권장
+    @NotBlank private String mediaName;
+
+    @NotNull  private Category category;
+    @NotNull  private LocalDateTime publishedAt;
+
+    // ===== Hanja + Quizzes =====
+    @NotNull @Size(min = 0)
+    private List<HanjaBlock> hanjas;  // 버전별 한자와 그 한자에 속한 퀴즈들
+
+    @Getter @Setter
+    @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class HanjaBlock {
+        @NotNull private SummaryVersion version;  // ORIGINAL | SHORT | MIDDLE
+        @NotBlank private String word;
+        @NotBlank private String definition;
+
+        @Builder.Default
+        private List<QuizBlock> quizzes = List.of(); // 선택
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class QuizBlock {
+        @NotBlank private String question;
+        @NotBlank private String answer1;
+        @NotBlank private String answer2;
+        @NotBlank private String answer3;
+        @NotNull  @Min(1) @Max(3) private Integer correct; // 1~3
+    }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleResponseDto.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleResponseDto.java
@@ -2,9 +2,9 @@ package com.newslearning.domain.article.dto;
 
 import java.time.LocalDateTime;
 
-import com.newslearning.domain.article.Article;
+import com.newslearning.domain.article.entity.Article;
 
-public record ArticleResponseDto(
+public record ArticleResponseDTO(
     Long id,
     String title,
     String imageUrl,
@@ -12,8 +12,8 @@ public record ArticleResponseDto(
     String reporter,
     LocalDateTime publishedAt
 ) {
-    public static ArticleResponseDto from(Article article) {
-        return new ArticleResponseDto(
+    public static ArticleResponseDTO from(Article article) {
+        return new ArticleResponseDTO(
             article.getId(),
             article.getTitle(),
             article.getImageUrl(),

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleResponseDto.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleResponseDto.java
@@ -1,0 +1,25 @@
+package com.newslearning.domain.article.dto;
+
+import java.time.LocalDateTime;
+
+import com.newslearning.domain.article.Article;
+
+public record ArticleResponseDto(
+    Long id,
+    String title,
+    String imageUrl,
+    String category,
+    String reporter,
+    LocalDateTime publishedAt
+) {
+    public static ArticleResponseDto from(Article article) {
+        return new ArticleResponseDto(
+            article.getId(),
+            article.getTitle(),
+            article.getImageUrl(),
+            article.getCategory().getKorean(),
+            article.getReporter(),
+            article.getPublishedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleScrollResponseDto.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleScrollResponseDto.java
@@ -3,8 +3,8 @@ package com.newslearning.domain.article.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record ArticleScrollResponseDto(
-    List<ArticleResponseDto> articles,
+public record ArticleScrollResponseDTO(
+    List<ArticleResponseDTO> articles,
     boolean hasNext,
     LocalDateTime nextCursorPublishedAt
 ) {}

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleScrollResponseDto.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleScrollResponseDto.java
@@ -1,0 +1,10 @@
+package com.newslearning.domain.article.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ArticleScrollResponseDto(
+    List<ArticleResponseDto> articles,
+    boolean hasNext,
+    LocalDateTime nextCursorPublishedAt
+) {}

--- a/backend/src/main/java/com/newslearning/domain/article/entity/Article.java
+++ b/backend/src/main/java/com/newslearning/domain/article/entity/Article.java
@@ -1,4 +1,4 @@
-package com.newslearning.domain.article;
+package com.newslearning.domain.article.entity;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;

--- a/backend/src/main/java/com/newslearning/domain/article/entity/SummaryVersion.java
+++ b/backend/src/main/java/com/newslearning/domain/article/entity/SummaryVersion.java
@@ -1,0 +1,5 @@
+package com.newslearning.domain.article.entity;
+
+public enum SummaryVersion {
+    ORIGINAL, SHORT, MIDDLE
+}

--- a/backend/src/main/java/com/newslearning/domain/hanja/Hanja.java
+++ b/backend/src/main/java/com/newslearning/domain/hanja/Hanja.java
@@ -1,0 +1,62 @@
+package com.newslearning.domain.hanja;
+
+import java.time.LocalDateTime;
+
+import com.newslearning.domain.article.entity.Article;
+import com.newslearning.domain.article.entity.SummaryVersion;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "hanja",
+       uniqueConstraints = {
+           @UniqueConstraint(name = "uk_article_version_word",
+                             columnNames = {"article_id", "version", "word"})
+       },
+       indexes = {
+           @Index(name = "idx_hanja_article_version", columnList = "article_id, version")
+       })
+public class Hanja {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "version", nullable = false)
+    private SummaryVersion version;
+
+    @Column(nullable = false, length = 100)
+    private String word;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String definition;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/newslearning/domain/hanja/HanjaController.java
+++ b/backend/src/main/java/com/newslearning/domain/hanja/HanjaController.java
@@ -1,0 +1,8 @@
+package com.newslearning.domain.hanja;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HanjaController {
+    
+}

--- a/backend/src/main/java/com/newslearning/domain/hanja/HanjaRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/hanja/HanjaRepository.java
@@ -1,0 +1,15 @@
+package com.newslearning.domain.hanja;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.newslearning.domain.article.entity.SummaryVersion;
+
+public interface HanjaRepository extends JpaRepository<Hanja, Long> {
+    // 특정 기사에 대한 한자 목록을 조회
+    List<Hanja> findByArticleId(Long articleId);
+    
+    // 특정 기사와 버전에 대한 한자 목록을 조회
+    List<Hanja> findByArticleIdAndVersion(Long articleId, SummaryVersion version);
+}

--- a/backend/src/main/java/com/newslearning/domain/hanja/HanjaService.java
+++ b/backend/src/main/java/com/newslearning/domain/hanja/HanjaService.java
@@ -1,0 +1,43 @@
+package com.newslearning.domain.hanja;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newslearning.domain.article.entity.SummaryVersion;
+
+import lombok.RequiredArgsConstructor;
+
+
+@Service
+@RequiredArgsConstructor
+public class HanjaService {
+
+    private final HanjaRepository hanjaRepository;
+
+    // 특정 기사에 대한 한자 목록을 버전별로 그룹화하여 조회
+    @Transactional(readOnly = true)
+    public Map<SummaryVersion, List<Hanja>> findGroupedByVersion(Long articleId) {
+        List<Hanja> all = hanjaRepository.findByArticleId(articleId);
+
+        Map<SummaryVersion, List<Hanja>> grouped = new EnumMap<>(SummaryVersion.class);
+        for (Hanja h : all) {
+            grouped.computeIfAbsent(h.getVersion(), k -> new ArrayList<>()).add(h);
+        }
+
+        for (SummaryVersion v : SummaryVersion.values()) {
+            grouped.putIfAbsent(v, List.of());
+        }
+        return grouped;
+    }
+
+    // 특정 기사와 버전에 해당하는 한자 목록 조회 (퀴즈용)
+    @Transactional(readOnly = true)
+    public List<Hanja> findByArticleAndVersion(Long articleId, SummaryVersion version) {
+        return hanjaRepository.findByArticleIdAndVersion(articleId, version);
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/hanja/dto/HanjaDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/hanja/dto/HanjaDTO.java
@@ -1,0 +1,17 @@
+package com.newslearning.domain.hanja.dto;
+
+import com.newslearning.domain.hanja.Hanja;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @NoArgsConstructor @AllArgsConstructor
+public class HanjaDTO {
+    private Long id;
+    private String word;
+    private String definition;
+
+    public static HanjaDTO from(Hanja h) {
+        return new HanjaDTO(h.getId(), h.getWord(), h.getDefinition());
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/quiz/Quiz.java
+++ b/backend/src/main/java/com/newslearning/domain/quiz/Quiz.java
@@ -1,0 +1,62 @@
+package com.newslearning.domain.quiz;
+
+import java.time.LocalDateTime;
+
+import com.newslearning.domain.article.entity.Article;
+import com.newslearning.domain.hanja.Hanja;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Index;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Table(name = "quizzes",
+       indexes = {
+           @Index(name = "idx_quiz_hanja", columnList = "hanja_id"),
+           @Index(name = "idx_quiz_article", columnList = "article_id")
+       })
+public class Quiz {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) 
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hanja_id", nullable = false)
+    private Hanja hanja;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String question;
+
+    @Column(name = "answer1", length = 255)
+    private String answer1;
+    @Column(name = "answer2", length = 255)
+    private String answer2;
+    @Column(name = "answer3", length = 255)
+    private String answer3;
+
+    @Column(name = "correct", nullable = false)
+    private Integer correct; // 1~3
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/newslearning/domain/quiz/QuizController.java
+++ b/backend/src/main/java/com/newslearning/domain/quiz/QuizController.java
@@ -1,0 +1,46 @@
+package com.newslearning.domain.quiz;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.newslearning.domain.article.entity.SummaryVersion;
+import com.newslearning.domain.quiz.dto.QuizItemDTO;
+import com.newslearning.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/articles")
+@RequiredArgsConstructor
+public class QuizController {
+    
+    private final QuizService quizService;
+
+    @Operation(summary = "기사+버전에 대한 퀴즈 목록 조회")
+    @GetMapping("/{id}/quizzes")
+    public ResponseEntity<ApiResponse<List<QuizItemDTO>>> getQuizzes(
+            @PathVariable Long id,
+            @RequestParam SummaryVersion version
+    ) {
+        var quizzes = quizService.findQuizzesByArticleAndVersion(id, version);
+
+        List<QuizItemDTO> items = new ArrayList<>(quizzes.size());
+        for (Quiz q : quizzes) {
+            items.add(new QuizItemDTO(
+                q.getId(),
+                q.getHanja().getId(),
+                q.getQuestion(),
+                List.of(q.getAnswer1(), q.getAnswer2(), q.getAnswer3())
+            ));
+        }
+        return ResponseEntity.ok(ApiResponse.success(items));
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/quiz/QuizRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/quiz/QuizRepository.java
@@ -1,0 +1,11 @@
+package com.newslearning.domain.quiz;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    // 특정 한자 ID 목록에 해당하는 퀴즈를 조회
+    List<Quiz> findByHanjaIdIn(Collection<Long> hanjaIds);
+}

--- a/backend/src/main/java/com/newslearning/domain/quiz/QuizService.java
+++ b/backend/src/main/java/com/newslearning/domain/quiz/QuizService.java
@@ -1,0 +1,36 @@
+package com.newslearning.domain.quiz;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newslearning.domain.article.entity.SummaryVersion;
+import com.newslearning.domain.hanja.Hanja;
+import com.newslearning.domain.hanja.HanjaService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+    
+    private final QuizRepository quizRepository;
+    private final HanjaService hanjaService;
+
+    /**
+     * 사용자가 "퀴즈풀기"를 눌렀을 때 호출:
+     * - 해당 기사 + 버전에 해당하는 Hanja를 모두 찾고
+     * - 그 Hanja들에 걸린 Quiz를 한 번에 가져온다.
+     */
+    @Transactional(readOnly = true)
+    public List<Quiz> findQuizzesByArticleAndVersion(Long articleId, SummaryVersion version) {
+        List<Hanja> hanjas = hanjaService.findByArticleAndVersion(articleId, version);
+        List<Long> hanjaIds = hanjas.stream().map(Hanja::getId).toList();
+        if (hanjaIds.isEmpty()) return List.of();
+        List<Quiz> quizzes = quizRepository.findByHanjaIdIn(hanjaIds);
+        return quizzes;
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/quiz/dto/QuizItemDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/quiz/dto/QuizItemDTO.java
@@ -1,0 +1,22 @@
+package com.newslearning.domain.quiz.dto;
+
+import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "QuizItem", description = "한자어 퀴즈 항목")
+public class QuizItemDTO {
+    @Schema(description = "퀴즈 ID")
+    private Long quizId;
+    @Schema(description = "한자 ID")
+    private Long hanjaId;
+    @Schema(description = "문항")
+    private String question;
+    @Schema(description = "보기 3개")
+    private List<String> options;
+}


### PR DESCRIPTION
### ✨ 작업 내용 요약

- 기사 목록 조회 API (커서 무한스크롤방식)
- 기사 단일 조회
  - 한자어까지 포함됨
- 기사 등록 API 
  - 기사, 한자, 퀴즈 저장
- 퀴즈 조회 API

---

### ✅ 테스트 결과

- 수동점검(Postman)

> 필요 시 스크린샷, 로그, API 예시 등을 첨부해주세요.
