### PR TITLE
[BE] 키워드 매칭 엔진 구축 및 기사 등록 시 명사 기반 알림 트리거

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	// Validation API
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Aho–Corasick 문자열 매칭 라이브러리
+	implementation 'org.ahocorasick:ahocorasick:0.6.3'
+
 	// 테스트용 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
+++ b/backend/src/main/java/com/newslearning/domain/article/ArticleService.java
@@ -17,13 +17,16 @@ import com.newslearning.domain.article.entity.Article;
 import com.newslearning.domain.hanja.Hanja;
 import com.newslearning.domain.hanja.HanjaRepository;
 import com.newslearning.domain.hanja.HanjaService;
+import com.newslearning.domain.keyword.match.KeywordMatchEngine;
 import com.newslearning.domain.quiz.Quiz;
 import com.newslearning.domain.quiz.QuizRepository;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ArticleService {
@@ -32,15 +35,8 @@ public class ArticleService {
     private final HanjaService hanjaService;
     private final HanjaRepository hanjaRepository;
     private final QuizRepository quizRepository;
+    private final KeywordMatchEngine matchEngine;
 
-    @Getter
-    @AllArgsConstructor
-    public static class IngestResult {
-        private Long articleId;
-        private int hanjaInserted;
-        private int quizInserted;
-    }
-    
     // 커서 기반 무한 스크롤을 위한 기사 목록 조회
     @Transactional(readOnly = true)
     public ArticleScrollResponseDTO getArticles(String keyword, String category, LocalDateTime cursorPublishedAt, int size) {
@@ -103,7 +99,7 @@ public class ArticleService {
      * 유니크 제약 위반 시 DataIntegrityViolationException 발생 가능.
      */
     @Transactional
-    public IngestResult addArticle(ArticleRequestDTO req) {
+    public void addArticle(ArticleRequestDTO req) {
         // 0) 타임스탬프 기본값
         LocalDateTime createdTs = LocalDateTime.now();
 
@@ -158,6 +154,14 @@ public class ArticleService {
             }
         }
 
-        return new IngestResult(article.getId(), hanjaCnt, quizCnt);
+        // 3) 명사 기반 유저 키워드 매칭
+        var hits = matchEngine.matchByNouns(req.getNouns());
+        if (hits.isEmpty()) {
+            log.info("[KeywordMatch] articleId={} hits=0", article.getId());
+        } else {
+            var preview = hits.stream().toList();
+            log.info("[KeywordMatch] articleId={} totalHits={} sample={}",
+                    article.getId(), hits.size(), preview);
+        }
     }
 }

--- a/backend/src/main/java/com/newslearning/domain/article/dto/ArticleRequestDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/article/dto/ArticleRequestDTO.java
@@ -22,7 +22,7 @@ public class ArticleRequestDTO {
 
     private String imageUrl;
     @NotBlank private String reporter;
-    @NotBlank private String sourceUrl;   // 중복 방지 키로 사용 권장
+    @NotBlank private String sourceUrl;  
     @NotBlank private String mediaName;
 
     @NotNull  private Category category;
@@ -32,6 +32,12 @@ public class ArticleRequestDTO {
     @NotNull @Size(min = 0)
     private List<HanjaBlock> hanjas;  // 버전별 한자와 그 한자에 속한 퀴즈들
 
+    // ===== Nouns (알림 매칭용, 비저장) =====
+    // 요청 바디에서만 받아 사용 후 폐기 (엔티티에 매핑 X)
+    @Builder.Default
+    @Size(min = 0, max = 200, message = "명사 리스트는 최대 200개까지 허용됩니다.")
+    private List<@NotBlank @Size(max = 50) String> nouns = List.of();
+
     @Getter @Setter
     @NoArgsConstructor @AllArgsConstructor @Builder
     public static class HanjaBlock {
@@ -40,7 +46,7 @@ public class ArticleRequestDTO {
         @NotBlank private String definition;
 
         @Builder.Default
-        private List<QuizBlock> quizzes = List.of(); // 선택
+        private List<QuizBlock> quizzes = List.of();
     }
 
     @Getter @Setter

--- a/backend/src/main/java/com/newslearning/domain/keyword/Keyword.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/Keyword.java
@@ -1,0 +1,34 @@
+package com.newslearning.domain.keyword;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+    name = "keyword",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "normalized_keyword"})
+)
+@Getter 
+@Builder
+@NoArgsConstructor 
+@AllArgsConstructor
+public class Keyword {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 아직 User 엔티티 미병합 → 값으로만 보관(추후 ManyToOne으로 대체 가능)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "keyword", nullable = false, length = 200)
+    private String keyword;
+
+    @Column(name = "normalized_keyword", nullable = false, length = 200)
+    private String normalizedKeyword;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/newslearning/domain/keyword/KeywordController.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/KeywordController.java
@@ -1,0 +1,29 @@
+package com.newslearning.domain.keyword;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import com.newslearning.domain.keyword.dto.KeywordRequestDTO;
+import com.newslearning.global.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/keywords")
+public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> add(@RequestBody @Validated KeywordRequestDTO req) {
+        keywordService.addKeyword(req.userId(), req.keyword());
+        return ResponseEntity.ok(ApiResponse.success()); 
+    }
+
+    @DeleteMapping("/{keywordId}")
+    public ResponseEntity<ApiResponse<Void>> delete(@RequestParam Long userId, @PathVariable Long keywordId) {
+        keywordService.deleteKeyword(userId, keywordId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/keyword/KeywordRepository.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/KeywordRepository.java
@@ -1,0 +1,18 @@
+package com.newslearning.domain.keyword;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    // 사용자 ID로 키워드 목록 조회
+    List<Keyword> findByUserId(Long userId);
+
+    // 사용자 ID와 정규화된 키워드로 키워드 조회
+    Optional<Keyword> findByUserIdAndNormalizedKeyword(Long userId, String normalized);
+
+    // 사용자 ID와 정규화된 키워드로 존재 여부 확인
+    boolean existsByUserIdAndNormalizedKeyword(Long userId, String normalized);
+}

--- a/backend/src/main/java/com/newslearning/domain/keyword/KeywordService.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/KeywordService.java
@@ -1,0 +1,58 @@
+package com.newslearning.domain.keyword;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newslearning.domain.keyword.match.KeywordMatchEngine;
+
+import java.text.Normalizer;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+    private final KeywordMatchEngine matchEngine;
+
+    // 키워드 정규화: 공백 제거, 소문자 변환, NFKC 정규화
+    private String norm(String s) {
+        if (s == null) return "";
+        String out = s.trim().toLowerCase();
+        out = Normalizer.normalize(out, Normalizer.Form.NFKC);
+        return out;
+    }
+
+    @Transactional
+    public void addKeyword(Long userId, String keyword) {
+        String normalized = norm(keyword);
+        if (normalized.isEmpty()) throw new IllegalArgumentException("빈 키워드");
+
+        // 이미 있으면 아무 것도 하지 않음
+        if (keywordRepository.existsByUserIdAndNormalizedKeyword(userId, normalized)) {
+            return;
+        }
+
+        keywordRepository.save(Keyword.builder()
+                .userId(userId)
+                .keyword(keyword)
+                .normalizedKeyword(normalized)
+                .build());
+
+        matchEngine.rebuild();
+    }
+
+    @Transactional
+    public void deleteKeyword(Long userId, Long keywordId) {
+        var kw = keywordRepository.findById(keywordId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 키워드 ID입니다. Id: " + keywordId));
+
+        // 본인 키워드만 삭제 가능
+        if (!kw.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인 키워드만 삭제 가능합니다.");
+        }
+
+        keywordRepository.delete(kw);
+        matchEngine.rebuild();
+    }
+}

--- a/backend/src/main/java/com/newslearning/domain/keyword/dto/KeywordRequestDTO.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/dto/KeywordRequestDTO.java
@@ -1,0 +1,10 @@
+package com.newslearning.domain.keyword.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record KeywordRequestDTO(
+        @NotNull Long userId,
+        @NotBlank @Size(max = 200) String keyword
+) {}

--- a/backend/src/main/java/com/newslearning/domain/keyword/match/KeywordMatchEngine.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/match/KeywordMatchEngine.java
@@ -1,0 +1,18 @@
+package com.newslearning.domain.keyword.match;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * 키워드 매칭 엔진 인터페이스
+ * Aho-Corasick 알고리즘을 사용하여 키워드 매칭을 수행합니다.
+ */
+public interface KeywordMatchEngine {
+    // 키워드 매칭 결과를 나타내는 Hit 레코드
+    record Hit(Long userId, Long keywordId) {}
+
+    Set<Hit> matchByNouns(Collection<String> nouns);
+
+    // 키워드 변경 시 재빌드 메서드
+    void rebuild(); 
+}

--- a/backend/src/main/java/com/newslearning/domain/keyword/match/KeywordMatcher.java
+++ b/backend/src/main/java/com/newslearning/domain/keyword/match/KeywordMatcher.java
@@ -1,0 +1,93 @@
+package com.newslearning.domain.keyword.match;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+import com.newslearning.domain.keyword.KeywordRepository;
+
+import org.ahocorasick.trie.Trie;
+
+import jakarta.annotation.PostConstruct;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * 키워드 매칭 엔진 구현체
+ * Aho-Corasick 알고리즘을 사용
+ * DB에 저장된 모든 키워드를 가져와서 -> 
+ * Aho-Corasick 알고리즘이란 빠른 검색기를 만들어 둠 ->
+ * 이후 기사 본문이 들어오면 한 번만 읽으면서 유저 키워드가 있는지 찾아냄
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KeywordMatcher implements KeywordMatchEngine {
+
+    private final KeywordRepository keywordRepository;
+    // Aho-Corasick Trie와 인덱스 맵을 AtomicReference로 관리
+    private final AtomicReference<Trie> trieRef = new AtomicReference<>();
+    // 키워드 정규화된 문자열과 해당 키워드 ID의 매핑
+    private final AtomicReference<Map<String, Set<Hit>>> indexRef = new AtomicReference<>();
+
+    // 초기화 메서드: 애플리케이션 시작 시 키워드 매칭 엔진을 재빌드.
+    @PostConstruct
+    public void init() { rebuild(); }
+
+    /**
+     * 키워드 매칭 엔진을 재빌드합니다.
+     * 데이터베이스에서 모든 키워드를 조회하여 Aho-Corasick Trie를 구성.
+     * 키워드 추가/삭제 시 KeywordService가 rebuild()를 실행해서 최신 상태 유지.
+     */
+    @Override
+    public synchronized void rebuild() {
+        var all = keywordRepository.findAll();
+        Map<String, Set<Hit>> map = new HashMap<>();
+        for (var k : all) {
+            map.computeIfAbsent(k.getNormalizedKeyword(), __ -> new HashSet<>())
+               .add(new Hit(k.getUserId(), k.getId()));
+        }
+        // Trie.TrieBuilder builder = Trie.builder().onlyWholeWords();
+        Trie.TrieBuilder builder = Trie.builder();
+        map.keySet().forEach(builder::addKeyword);
+        trieRef.set(builder.build());
+        indexRef.set(map);
+
+        // ✅ 로그 추가
+        log.info("🔄 KeywordMatcher rebuilt. 총 키워드 개수 = {}", map.size());
+        map.forEach((keyword, hits) ->
+            log.debug(" - '{}' -> {}", keyword, hits)
+        );
+    }
+
+    @Override
+    public Set<Hit> matchByNouns(Collection<String> nouns) {
+        var idx = indexRef.get();
+
+        if (idx == null || nouns.isEmpty()) return Set.of();
+
+        // 전처리: trim + toLowerCase + 빈값 제거 + 중복 제거
+        Set<String> normalized = nouns.stream()
+            .filter(Objects::nonNull)
+            .map(s -> s.trim().toLowerCase())
+            .filter(s -> !s.isEmpty())
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+
+        Set<Hit> hits = new HashSet<>();
+        for (String n : normalized) {
+            var owners = idx.get(n); // 키워드가 "정규화된 문자열" 기준으로 들어있음
+            if (owners != null && !owners.isEmpty()) {
+                hits.addAll(owners);
+                log.debug("✅ noun 매칭: '{}' -> {}", n, owners);
+            }
+        }
+        if (hits.isEmpty()) {
+            log.info("ℹ️ noun 기반 매칭 결과 없음. (nouns.size={})", normalized.size());
+        } else {
+            log.info("🔔 noun 기반 매칭 결과: 총 {}건", hits.size());
+        }
+        return hits;
+    }
+}
+

--- a/backend/src/main/java/com/newslearning/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/newslearning/domain/user/controller/UserController.java
@@ -20,6 +20,21 @@ public class UserController {
 		this.userService = userService;
 	}
 	
+	@GetMapping("/social-login")
+   public ResponseEntity<String> callback(
+           @RequestParam(name = "code") String code,
+           @RequestParam(name = "state", required = false) String state,
+           @RequestParam(name = "error", required = false) String error,
+           @RequestParam(name = "error_description", required = false) String errorDesc) {
+
+       if (error != null) {
+           return ResponseEntity.badRequest()
+                   .body("naver error=" + error + ", desc=" + errorDesc);
+       }
+       return ResponseEntity.ok("code=" + code + ", state=" + state);
+   }
+
+
 	// 내정보 확인
 	@GetMapping("/user/myInfo")
 	public ResponseEntity<ApiResponse<UserDTO>> myInfo() {


### PR DESCRIPTION
### ✨ 작업 내용 요약
- 키워드 매칭 엔진 구현
  - DB에 저장된 키워드들을 불러와 Aho-Corasick Trie로 빌드
  - 키워드와 사용자 매핑을 인덱스로 관리하여 빠른 검색 지원
- 명사 기반 매칭 기능 추가
  - ArticleRequestDTO에 nouns 필드 추가(@Size, @NotBlank 검증)
  - 기사 저장 시 요청 바디의 명사 리스트를 활용해 matchByNouns() 실행
  - DB 저장 없이 알림 트리거용으로만 사용 (아직 알림은 미구현)

---

### ✅ 테스트 결과

- 포스트맨 요청 예시
```
{
  "title": "제목 테스트",
  "content": "원문 테스트",
  "shortSummary": "짧은요약 테스트",
  "middleSummary": "중간요약 테스트",
  "imageUrl": "http://img.com/1.jpg",
  "reporter": "테스터",
  "sourceUrl": "http://source.com/1",
  "mediaName": "뉴스미디어",
  "category": "POLITICS",
  "publishedAt": "2025-07-01T10:00:00",
  "hanjas": [
    {
      "version": "ORIGINAL",
      "word": "기소",
      "definition": "검사가 피의자를 형사재판에 회부하는 절차.",
      "quizzes": [
        {
          "question": "다음 중 '기소'의 의미로 알맞은 것은?",
          "answer1": "무죄 선고",
          "answer2": "형사재판에 회부",
          "answer3": "수사 종결",
          "correct": 2
        }
      ]
    }
  ],
  "nouns": ["검찰", "장관", "기소", "코스피", "정치", "개혁"]
}
```

- 로그 결과 예시
```
🔔 noun 기반 매칭 결과: 총 3건
[KeywordMatch] articleId=15 totalHits=3 sample=[Hit(userId=1, keywordId=12), ...]
```